### PR TITLE
Export `Renderer`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,5 +13,6 @@
 
 module.exports.Node = require('./node');
 module.exports.Parser = require('./blocks');
+module.exports.Renderer = require('./render/renderer');
 module.exports.HtmlRenderer = require('./render/html');
 module.exports.XmlRenderer = require('./render/xml');


### PR DESCRIPTION
Export the `Renderer` class so consumers can use it as a base class for their own custom Renderers.